### PR TITLE
fix: updated async-storage peer dependency

### DIFF
--- a/packages/rn-async-storage-flipper/package.json
+++ b/packages/rn-async-storage-flipper/package.json
@@ -18,7 +18,7 @@
     },
     "license": "MIT",
     "peerDependencies": {
-        "@react-native-community/async-storage": "^1.4.0",
+        "@react-native-async-storage/async-storage": "^1.15.2",
         "react-native": "^0.62.0",
         "react-native-flipper": "^0.37.0"
     },


### PR DESCRIPTION
For #22 

- changed to new `@react-native-async-storage/async-storage` package

---

Need to finagle some testing to make sure this doesn't blow anything up, but here's the base update. 